### PR TITLE
Ci 849 unable to show filter choices

### DIFF
--- a/src/Web/Sfa.Das.Sas.Web/Services/MappingActions/ProviderSearchMappingHelper.cs
+++ b/src/Web/Sfa.Das.Sas.Web/Services/MappingActions/ProviderSearchMappingHelper.cs
@@ -24,7 +24,7 @@ namespace Sfa.Das.Sas.Web.Services.MappingActions
                                    {
                                        Title = GetName(item.Key),
                                        Count = item.Value ?? 0L,
-                                       Checked = selectedTrainingOptions?.Contains(item.Key) ?? false,
+                                       Checked = selectedTrainingOptions?.Contains(item.Key.ToLower()) ?? false,
                                        Value = item.Key
                                    });
             }

--- a/src/Web/Sfa.Das.Sas.Web/Web.config
+++ b/src/Web/Sfa.Das.Sas.Web/Web.config
@@ -29,7 +29,8 @@
     <add key="EnvironmentName" value="local" />
     <add key="ApprenticeshipIndexAlias" value="localapprenticeshipindexalias" />
     <add key="ProviderIndexAlias" value="localproviderindexalias" />
-    <add key="ApprenticeshipApiBaseUrl" value="https://localhost:44319" />
+    <!--<add key="ApprenticeshipApiBaseUrl" value="https://localhost:44319" />-->
+    <add key="ApprenticeshipApiBaseUrl" value="https://at-fatapi.apprenticeships.sfa.bis.gov.uk/" />
 
     
     <add key="iKey" value="" />

--- a/src/Web/Sfa.Das.Sas.Web/Web.config
+++ b/src/Web/Sfa.Das.Sas.Web/Web.config
@@ -29,9 +29,8 @@
     <add key="EnvironmentName" value="local" />
     <add key="ApprenticeshipIndexAlias" value="localapprenticeshipindexalias" />
     <add key="ProviderIndexAlias" value="localproviderindexalias" />
-    <!--<add key="ApprenticeshipApiBaseUrl" value="https://localhost:44319" />-->
-    <add key="ApprenticeshipApiBaseUrl" value="https://at-fatapi.apprenticeships.sfa.bis.gov.uk/" />
-
+    <add key="ApprenticeshipApiBaseUrl" value="https://localhost:44319" />
+  
     
     <add key="iKey" value="" />
     <add key="ElasticServerUrls" value="http://127.0.0.1:9200,http://192.168.99.100:9200,http://docker.local:9200" />

--- a/src/Web/Sfa.Das.Sas.Web/Web.config
+++ b/src/Web/Sfa.Das.Sas.Web/Web.config
@@ -30,7 +30,6 @@
     <add key="ApprenticeshipIndexAlias" value="localapprenticeshipindexalias" />
     <add key="ProviderIndexAlias" value="localproviderindexalias" />
     <add key="ApprenticeshipApiBaseUrl" value="https://localhost:44319" />
-  
     
     <add key="iKey" value="" />
     <add key="ElasticServerUrls" value="http://127.0.0.1:9200,http://192.168.99.100:9200,http://docker.local:9200" />

--- a/src/Web/Sfa.Das.Sas.Web/Web.config
+++ b/src/Web/Sfa.Das.Sas.Web/Web.config
@@ -31,6 +31,7 @@
     <add key="ProviderIndexAlias" value="localproviderindexalias" />
     <add key="ApprenticeshipApiBaseUrl" value="https://localhost:44319" />
     
+    
     <add key="iKey" value="" />
     <add key="ElasticServerUrls" value="http://127.0.0.1:9200,http://192.168.99.100:9200,http://docker.local:9200" />
     <add key="ga.gtm.trackingid" value="" />

--- a/src/Web/Sfa.Das.Sas.Web/Web.config
+++ b/src/Web/Sfa.Das.Sas.Web/Web.config
@@ -31,7 +31,6 @@
     <add key="ProviderIndexAlias" value="localproviderindexalias" />
     <add key="ApprenticeshipApiBaseUrl" value="https://localhost:44319" />
     
-    
     <add key="iKey" value="" />
     <add key="ElasticServerUrls" value="http://127.0.0.1:9200,http://192.168.99.100:9200,http://docker.local:9200" />
     <add key="ga.gtm.trackingid" value="" />


### PR DESCRIPTION
The fix that is needed to allow the tickboxed choices to propagate through when the page refreshes.  (Issue caused by ES5 using a different source for data about training options from ES2, that doesn't go through a mapping exercise to render it lowercase)