### PR TITLE
Removed Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString

### DIFF
--- a/src/Web/Sfa.Das.Sas.Web.CloudService/Configuration/ServiceDefinition.Cloud.csdef
+++ b/src/Web/Sfa.Das.Sas.Web.CloudService/Configuration/ServiceDefinition.Cloud.csdef
@@ -10,7 +10,6 @@
       </Site>
     </Sites>
     <ConfigurationSettings>
-      <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" />
       <Setting name="PostcodeUrl" />
       <Setting name="SurveyUrl" />
       <Setting name="ElasticServerUrls" />

--- a/src/Web/Sfa.Das.Sas.Web.CloudService/Configuration/ServiceDefinition.Release.csdef
+++ b/src/Web/Sfa.Das.Sas.Web.CloudService/Configuration/ServiceDefinition.Release.csdef
@@ -10,7 +10,6 @@
       </Site>
     </Sites>
     <ConfigurationSettings>
-      <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" />
       <Setting name="PostcodeUrl" />
       <Setting name="SurveyUrl" />
       <Setting name="ElasticServerUrls" />

--- a/src/Web/Sfa.Das.Sas.Web.CloudService/ServiceConfiguration.Cloud.cscfg
+++ b/src/Web/Sfa.Das.Sas.Web.CloudService/ServiceConfiguration.Cloud.cscfg
@@ -3,7 +3,6 @@
   <Role name="Sfa.Das.Sas.Web">
     <Instances count="1" />
     <ConfigurationSettings>
-      <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" value="__StorageConnectionString__" />
       <Setting name="PostcodeUrl" value="http://api.postcodes.io/postcodes/" />
       <Setting name="SurveyUrl" value="__SurveyUrl__" />
       <Setting name="ElasticServerUrls" value="__ElasticServerUrls__" />

--- a/src/Web/Sfa.Das.Sas.Web.CloudService/ServiceConfiguration.Local.cscfg
+++ b/src/Web/Sfa.Das.Sas.Web.CloudService/ServiceConfiguration.Local.cscfg
@@ -3,7 +3,6 @@
   <Role name="Sfa.Das.Sas.Web">
     <Instances count="1" />
     <ConfigurationSettings>
-      <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" value="UseDevelopmentStorage=true" />
       <Setting name="PostcodeUrl" value="http://api.postcodes.io/postcodes/" />
       <Setting name="SurveyUrl" value="https://www.surveymonkey.co.uk/r/F3LCBG6" />
       <Setting name="ElasticServerUrls" value="http://127.0.0.1:9200,http://192.168.99.100:9200,http://docker.local:9200" />

--- a/src/Web/Sfa.Das.Sas.Web.CloudService/ServiceConfiguration.PreProd.cscfg
+++ b/src/Web/Sfa.Das.Sas.Web.CloudService/ServiceConfiguration.PreProd.cscfg
@@ -3,7 +3,6 @@
   <Role name="Sfa.Das.Sas.Web">
     <Instances count="3" />
     <ConfigurationSettings>
-      <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" value="__StorageConnectionString__" />
       <Setting name="PostcodeUrl" value="http://api.postcodes.io/postcodes/" />
       <Setting name="SurveyUrl" value="__SurveyUrl__" />
       <Setting name="ElasticServerUrls" value="__ElasticServerUrls__" />

--- a/src/Web/Sfa.Das.Sas.Web.CloudService/ServiceConfiguration.Prod.cscfg
+++ b/src/Web/Sfa.Das.Sas.Web.CloudService/ServiceConfiguration.Prod.cscfg
@@ -3,7 +3,6 @@
   <Role name="Sfa.Das.Sas.Web">
     <Instances count="3" />
     <ConfigurationSettings>
-      <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" value="__StorageConnectionString__" />
       <Setting name="PostcodeUrl" value="http://api.postcodes.io/postcodes/" />
       <Setting name="SurveyUrl" value="__SurveyUrl__" />
       <Setting name="ElasticServerUrls" value="__ElasticServerUrls__" />

--- a/src/Web/Sfa.Das.Sas.Web.CloudService/ServiceConfiguration.Release.cscfg
+++ b/src/Web/Sfa.Das.Sas.Web.CloudService/ServiceConfiguration.Release.cscfg
@@ -3,7 +3,6 @@
   <Role name="Sfa.Das.Sas.Web">
     <Instances count="1" />
     <ConfigurationSettings>
-      <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" value="__StorageConnectionString__" />
       <Setting name="PostcodeUrl" value="http://api.postcodes.io/postcodes/" />
       <Setting name="SurveyUrl" value="__SurveyUrl__" />
       <Setting name="ElasticServerUrls" value="__ElasticServerUrls__" />

--- a/src/Web/Sfa.Das.Sas.Web.CloudService/ServiceDefinition.csdef
+++ b/src/Web/Sfa.Das.Sas.Web.CloudService/ServiceDefinition.csdef
@@ -10,7 +10,6 @@
       </Site>
     </Sites>
     <ConfigurationSettings>
-      <Setting name="Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString" />
       <Setting name="PostcodeUrl" />
       <Setting name="SurveyUrl" />
       <Setting name="ElasticServerUrls" />


### PR DESCRIPTION
Removed Microsoft.WindowsAzure.Plugins.Diagnostics.ConnectionString from cloud services' configuration files as it is unused.