### PR TITLE
FC-1129 basket showing 31 july

### DIFF
--- a/src/Web/Sfa.Das.Sas.Infrastructure/Mapping/FrameworkMapping.cs
+++ b/src/Web/Sfa.Das.Sas.Infrastructure/Mapping/FrameworkMapping.cs
@@ -61,7 +61,7 @@
                 KnowledgeQualification = document.KnowledgeQualification?.OrderBy(x => x),
                 CombinedQualification = document.CombinedQualification?.OrderBy(x => x),
                 EffectiveFrom = document.EffectiveFrom,
-                EffectiveTo = document.EffectiveTo,
+                EffectiveTo = document.EffectiveTo.Value.AddDays(1),
                 IsActiveFramework = document.IsActiveFramework,
                 FundingPeriods = document.FundingPeriods
             };

--- a/src/Web/Sfa.Das.Sas.Web.UnitTests/Infrastructure/Mapping/FrameworkMappingTests.cs
+++ b/src/Web/Sfa.Das.Sas.Web.UnitTests/Infrastructure/Mapping/FrameworkMappingTests.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using NUnit.Framework;
+using Sfa.Das.Sas.ApplicationServices.Models;
+using Sfa.Das.Sas.Infrastructure.Mapping;
+
+namespace Sfa.Das.Sas.Web.UnitTests.Infrastructure.Mapping
+{
+
+    using ApiFramework = SFA.DAS.Apprenticeships.Api.Types.Framework;
+
+    [TestFixture]
+    public class FrameworkMappingTests
+    {
+        private FrameworkMapping _sut;
+        private FrameworkSearchResultsItem _frameworkFromSearchResultsItem;
+        private ApiFramework _frameworkApiItem;
+        private DateTime _effectiveToDate;
+        private DateTime _expectedEffectiveToDate;
+
+        [SetUp]
+        public void Setup()
+        {
+            _effectiveToDate = new DateTime(2000, 1, 1, 0, 0, 0, 0, 0);
+            _expectedEffectiveToDate = new DateTime(2000, 1, 2, 0, 0, 0, 0, 0);
+
+            _sut = new FrameworkMapping();
+            _frameworkFromSearchResultsItem = new FrameworkSearchResultsItem()
+            {
+                Title = "Test Framework",
+                EffectiveTo = _effectiveToDate
+            };
+
+            _frameworkApiItem = new ApiFramework()
+            {
+                Title = "Test Framework From Api",
+                EffectiveTo = _effectiveToDate
+            };
+        }
+
+        [Test]
+        public void When_mapping_framework_from_Framework_search_results_Then_1_day_is_added_to_the_EffectiveTo_date()
+        {
+            var mappedFramework = _sut.MapToFramework(_frameworkApiItem);
+
+            Assert.AreEqual(_expectedEffectiveToDate, mappedFramework.EffectiveTo);
+        }
+
+        [Test]
+        public void When_mapping_framework_from_Framework_api_Then_1_day_is_added_to_the_EffectiveTo_date()
+        {
+            var mappedFramework = _sut.MapToFramework(_frameworkFromSearchResultsItem);
+
+            Assert.AreEqual(_expectedEffectiveToDate, mappedFramework.EffectiveTo);
+        }
+    }
+}

--- a/src/Web/Sfa.Das.Sas.Web.UnitTests/Sfa.Das.Sas.Web.UnitTests.csproj
+++ b/src/Web/Sfa.Das.Sas.Web.UnitTests/Sfa.Das.Sas.Web.UnitTests.csproj
@@ -259,6 +259,7 @@
     <Compile Include="Application\Validators\ProviderSearchQueryValidatorTests.cs" />
     <Compile Include="Infrastructure\Mapping\ApprenticeshipSearchResultsItemMappingTests.cs" />
     <Compile Include="Infrastructure\Mapping\ApprenticeshipSearchResultsMappingTests.cs" />
+    <Compile Include="Infrastructure\Mapping\FrameworkMappingTests.cs" />
     <Compile Include="Infrastructure\Providers\Api\ApiApprenticeshipSearchProviderTests.cs" />
     <Compile Include="Infrastructure\Repositories\ProviderApiRepository\ProviderApiRepositoryBase.cs" />
     <Compile Include="Infrastructure\Repositories\ProviderApiRepository\ProviderApiRepositorySearchProviderNameTest.cs" />


### PR DESCRIPTION
Previous fix in FC-723 only addressed mapping from search results but a seperate object is used to map when you retrieve a single framework, which is the call that GetBasket uses.